### PR TITLE
Document dispatcher variables separately from secrets

### DIFF
--- a/dispatcher/README.md
+++ b/dispatcher/README.md
@@ -20,10 +20,15 @@ Set these as **Space secrets** (Settings → Variables and secrets):
 
 | Variable | Purpose |
 |---|---|
-| `GH_APP_ID` | Your GitHub App ID (number) |
 | `GH_APP_PRIVATE_KEY` | PEM-encoded App private key. Newlines can be encoded as `\n`. |
 | `GH_WEBHOOK_SECRET` | Webhook secret you set on the GitHub App |
 | `HF_TOKEN` | HF token with **write** scope; used to dispatch Jobs |
+
+Set these as regular **Space variables**:
+
+| Variable | Purpose |
+|---|---|
+| `GH_APP_ID` | Your GitHub App ID (number) |
 | `HF_NAMESPACE` | Namespace (user or org) under which jobs are launched & billed |
 | `RUNNER_IMAGE_CPU` | (optional) Docker image for CPU jobs |
 | `RUNNER_IMAGE_GPU` | (optional) Docker image for GPU jobs |

--- a/dispatcher/app.py
+++ b/dispatcher/app.py
@@ -99,8 +99,9 @@ def make_app(settings: Settings | None = None) -> FastAPI:
         }
         if not configured:
             body["next_steps"] = (
-                "Set GH_APP_ID, GH_APP_PRIVATE_KEY, GH_WEBHOOK_SECRET, "
-                "HF_TOKEN, HF_NAMESPACE as Space secrets and restart."
+                "Set GH_APP_PRIVATE_KEY, GH_WEBHOOK_SECRET, HF_TOKEN as Space "
+                "secrets; set GH_APP_ID and HF_NAMESPACE as Space variables; "
+                "then restart."
             )
             body["error"] = _state(request).get("error")
         return body

--- a/setup/SETUP.md
+++ b/setup/SETUP.md
@@ -58,16 +58,21 @@ The App needs these permissions (already in the manifest):
 
 And subscribes to **`workflow_job`** events only.
 
-## 3. Set Space secrets
+## 3. Set Space configuration
 
-In your Space → Settings → **Variables and secrets**, add:
+In your Space → Settings → **Variables and secrets**, add these as **Secrets**:
+
+| Name | Value |
+|---|---|
+| `GH_APP_PRIVATE_KEY` | The contents of the `.pem` file. Paste the whole thing, including BEGIN/END lines. Newlines can be `\n` if the UI doesn't accept multi-line. |
+| `GH_WEBHOOK_SECRET` | The webhook secret from step 2 |
+| `HF_TOKEN` | An HF token with **write** scope |
+
+Add these as regular **Variables**:
 
 | Name | Value |
 |---|---|
 | `GH_APP_ID` | The App ID from step 2 |
-| `GH_APP_PRIVATE_KEY` | The contents of the `.pem` file. Paste the whole thing, including BEGIN/END lines. Newlines can be `\n` if the UI doesn't accept multi-line. |
-| `GH_WEBHOOK_SECRET` | The webhook secret from step 2 |
-| `HF_TOKEN` | An HF token with **write** scope |
 | `HF_NAMESPACE` | The HF namespace that pays for jobs (e.g. your user) |
 
 Restart the Space to pick them up.


### PR DESCRIPTION
## Summary
- clarify that only GH_APP_PRIVATE_KEY, GH_WEBHOOK_SECRET, and HF_TOKEN need to be Space Secrets
- document GH_APP_ID and HF_NAMESPACE as regular Space Variables
- update the unconfigured dispatcher next-steps text accordingly

## Verification
- uv run --extra dev pytest -q
- uv run --extra dev ruff check dispatcher setup