### PR TITLE
Default dispatcher jobs namespace to Space owner

### DIFF
--- a/dispatcher/README.md
+++ b/dispatcher/README.md
@@ -20,11 +20,16 @@ Set these as **Space secrets** (Settings → Variables and secrets):
 
 | Variable | Purpose |
 |---|---|
-| `GH_APP_ID` | Your GitHub App ID (number) |
 | `GH_APP_PRIVATE_KEY` | PEM-encoded App private key. Newlines can be encoded as `\n`. |
 | `GH_WEBHOOK_SECRET` | Webhook secret you set on the GitHub App |
 | `HF_TOKEN` | HF token with **write** scope; used to dispatch Jobs |
-| `HF_NAMESPACE` | Namespace (user or org) under which jobs are launched & billed |
+
+Set these as regular **Space variables**:
+
+| Variable | Purpose |
+|---|---|
+| `GH_APP_ID` | Your GitHub App ID (number) |
+| `HF_NAMESPACE` | (optional) Namespace (user or org) under which jobs are launched & billed. Defaults to this Space's owner. |
 | `RUNNER_IMAGE_CPU` | (optional) Docker image for CPU jobs |
 | `RUNNER_IMAGE_GPU` | (optional) Docker image for GPU jobs |
 | `JOB_TIMEOUT` | (optional) Default per-job timeout, e.g. `1h` |

--- a/dispatcher/app.py
+++ b/dispatcher/app.py
@@ -99,8 +99,9 @@ def make_app(settings: Settings | None = None) -> FastAPI:
         }
         if not configured:
             body["next_steps"] = (
-                "Set GH_APP_ID, GH_APP_PRIVATE_KEY, GH_WEBHOOK_SECRET, "
-                "HF_TOKEN, HF_NAMESPACE as Space secrets and restart."
+                "Set GH_APP_PRIVATE_KEY, GH_WEBHOOK_SECRET, HF_TOKEN as Space "
+                "secrets; set GH_APP_ID as a Space variable; then restart. "
+                "HF_NAMESPACE is optional and defaults to this Space's owner."
             )
             body["error"] = _state(request).get("error")
         return body

--- a/dispatcher/config.py
+++ b/dispatcher/config.py
@@ -25,6 +25,28 @@ def _optional(name: str, default: str) -> str:
     return os.environ.get(name, default).strip() or default
 
 
+def _hf_namespace() -> str:
+    value = os.environ.get("HF_NAMESPACE", "").strip()
+    if value:
+        return value
+
+    # HF Spaces expose these built-ins at runtime. Defaulting to the Space
+    # owner keeps duplicated Spaces easier to configure, while HF_NAMESPACE
+    # still allows operators to bill jobs to a different namespace.
+    value = os.environ.get("SPACE_AUTHOR_NAME", "").strip()
+    if value:
+        return value
+
+    space_id = os.environ.get("SPACE_ID", "").strip()
+    if "/" in space_id:
+        return space_id.split("/", 1)[0]
+
+    raise RuntimeError(
+        "Missing required env var: HF_NAMESPACE. "
+        "Set it explicitly when not running inside an HF Space."
+    )
+
+
 @dataclass(frozen=True)
 class Settings:
     # GitHub App
@@ -57,7 +79,7 @@ class Settings:
             gh_app_private_key=raw_key,
             webhook_secret=_required("GH_WEBHOOK_SECRET"),
             hf_token=_required("HF_TOKEN"),
-            hf_namespace=_required("HF_NAMESPACE"),
+            hf_namespace=_hf_namespace(),
             # Default to public base images + runtime install. Operators who
             # care about cold-start latency can point these at prebuilt
             # ghcr.io/<their-org>/jobs-actions-runner[:tag] images instead;

--- a/dispatcher/tests/test_config.py
+++ b/dispatcher/tests/test_config.py
@@ -1,0 +1,43 @@
+"""Tests for dispatcher environment configuration."""
+
+from __future__ import annotations
+
+import pytest
+
+from dispatcher.config import Settings
+
+
+@pytest.fixture
+def base_env(monkeypatch, rsa_keypair):
+    pem, _ = rsa_keypair
+    monkeypatch.setenv("GH_APP_ID", "123456")
+    monkeypatch.setenv("GH_APP_PRIVATE_KEY", pem)
+    monkeypatch.setenv("GH_WEBHOOK_SECRET", "s3cret")
+    monkeypatch.setenv("HF_TOKEN", "hf_test")
+    monkeypatch.delenv("HF_NAMESPACE", raising=False)
+    monkeypatch.delenv("SPACE_AUTHOR_NAME", raising=False)
+    monkeypatch.delenv("SPACE_ID", raising=False)
+
+
+def test_hf_namespace_uses_explicit_override(base_env, monkeypatch):
+    monkeypatch.setenv("HF_NAMESPACE", "billing-org")
+    monkeypatch.setenv("SPACE_AUTHOR_NAME", "space-owner")
+
+    assert Settings.from_env().hf_namespace == "billing-org"
+
+
+def test_hf_namespace_defaults_to_space_author(base_env, monkeypatch):
+    monkeypatch.setenv("SPACE_AUTHOR_NAME", "space-owner")
+
+    assert Settings.from_env().hf_namespace == "space-owner"
+
+
+def test_hf_namespace_falls_back_to_space_id_owner(base_env, monkeypatch):
+    monkeypatch.setenv("SPACE_ID", "space-owner/jobs-actions-dispatcher")
+
+    assert Settings.from_env().hf_namespace == "space-owner"
+
+
+def test_hf_namespace_required_outside_space(base_env):
+    with pytest.raises(RuntimeError, match="HF_NAMESPACE"):
+        Settings.from_env()

--- a/setup/SETUP.md
+++ b/setup/SETUP.md
@@ -58,17 +58,23 @@ The App needs these permissions (already in the manifest):
 
 And subscribes to **`workflow_job`** events only.
 
-## 3. Set Space secrets
+## 3. Set Space configuration
 
-In your Space → Settings → **Variables and secrets**, add:
+In your Space → Settings → **Variables and secrets**, add these as **Secrets**:
+
+| Name | Value |
+|---|---|
+| `GH_APP_PRIVATE_KEY` | The contents of the `.pem` file. Paste the whole thing, including BEGIN/END lines. Newlines can be `\n` if the UI doesn't accept multi-line. |
+| `GH_WEBHOOK_SECRET` | The webhook secret from step 2 |
+| `HF_TOKEN` | An HF token with **write** scope |
+
+Add this as a regular **Variable**:
 
 | Name | Value |
 |---|---|
 | `GH_APP_ID` | The App ID from step 2 |
-| `GH_APP_PRIVATE_KEY` | The contents of the `.pem` file. Paste the whole thing, including BEGIN/END lines. Newlines can be `\n` if the UI doesn't accept multi-line. |
-| `GH_WEBHOOK_SECRET` | The webhook secret from step 2 |
-| `HF_TOKEN` | An HF token with **write** scope |
-| `HF_NAMESPACE` | The HF namespace that pays for jobs (e.g. your user) |
+
+`HF_NAMESPACE` is optional. By default, jobs run under the owner namespace of the dispatcher Space. Set `HF_NAMESPACE` only if you want jobs billed to a different HF user or org.
 
 Restart the Space to pick them up.
 


### PR DESCRIPTION
## Summary
- default HF_NAMESPACE to the dispatcher Space owner via SPACE_AUTHOR_NAME / SPACE_ID
- keep explicit HF_NAMESPACE as an override for billing jobs to a different namespace
- update setup docs and unconfigured next-steps text
- add config tests for explicit override and Space built-in fallbacks

## Verification
- uv run --extra dev pytest -q
- uv run --extra dev ruff check dispatcher setup