### PR TITLE
Add dispatcher repository allowlist

### DIFF
--- a/dispatcher/.env.example
+++ b/dispatcher/.env.example
@@ -3,6 +3,7 @@ GH_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE K
 GH_WEBHOOK_SECRET=changeme
 HF_TOKEN=hf_xxxxxxxxxx
 HF_NAMESPACE=your-hf-user-or-org
+ALLOWED_GITHUB_REPOSITORIES=your-github-org/your-repo
 RUNNER_IMAGE_CPU=ghcr.io/abidlabs/jobs-actions-runner:latest
 RUNNER_IMAGE_GPU=ghcr.io/abidlabs/jobs-actions-runner-gpu:latest
 JOB_TIMEOUT=1h

--- a/dispatcher/README.md
+++ b/dispatcher/README.md
@@ -30,6 +30,7 @@ Set these as regular **Space variables**:
 |---|---|
 | `GH_APP_ID` | Your GitHub App ID (number) |
 | `HF_NAMESPACE` | (optional) Namespace (user or org) under which jobs are launched & billed. Defaults to this Space's owner. |
+| `ALLOWED_GITHUB_REPOSITORIES` | (recommended for public Apps) Comma-separated `owner/repo` allowlist. Webhooks from all other repositories are ignored. |
 | `RUNNER_IMAGE_CPU` | (optional) Docker image for CPU jobs |
 | `RUNNER_IMAGE_GPU` | (optional) Docker image for GPU jobs |
 | `JOB_TIMEOUT` | (optional) Default per-job timeout, e.g. `1h` |

--- a/dispatcher/app.py
+++ b/dispatcher/app.py
@@ -137,7 +137,12 @@ def make_app(settings: Settings | None = None) -> FastAPI:
         if event != "workflow_job":
             return {"ok": True, "skipped": f"event={event}"}
 
-        return await _handle_workflow_job(payload, gh=gh, hf=hf)
+        return await _handle_workflow_job(
+            payload,
+            gh=gh,
+            hf=hf,
+            allowed_repositories=s.allowed_github_repositories,
+        )
 
     return app
 
@@ -147,6 +152,7 @@ async def _handle_workflow_job(
     *,
     gh: GitHubAppClient,
     hf: HFJobsClient,
+    allowed_repositories: frozenset[str] | None = None,
 ) -> dict[str, Any]:
     action = payload.get("action")
     wj = payload.get("workflow_job", {})
@@ -161,6 +167,20 @@ async def _handle_workflow_job(
             return {"ok": True, "skipped": "no hf-jobs-* label", "labels": labels}
 
         repo = payload["repository"]["full_name"]
+        if (
+            allowed_repositories is not None
+            and repo.lower() not in allowed_repositories
+        ):
+            log.warning(
+                "skipping workflow job from repository outside allowlist",
+                extra={"repo": repo},
+            )
+            return {
+                "ok": True,
+                "skipped": "repository not allowed",
+                "repo": repo,
+            }
+
         installation_id = payload.get("installation", {}).get("id")
         if not installation_id:
             raise HTTPException(

--- a/dispatcher/config.py
+++ b/dispatcher/config.py
@@ -25,6 +25,25 @@ def _optional(name: str, default: str) -> str:
     return os.environ.get(name, default).strip() or default
 
 
+def _allowed_github_repositories() -> frozenset[str] | None:
+    raw = os.environ.get("ALLOWED_GITHUB_REPOSITORIES", "").strip()
+    if not raw:
+        return None
+
+    repositories = frozenset(repo.strip().lower() for repo in raw.split(","))
+    invalid = sorted(
+        repo
+        for repo in repositories
+        if not repo or repo.count("/") != 1 or any(not part for part in repo.split("/"))
+    )
+    if invalid:
+        raise RuntimeError(
+            "Invalid ALLOWED_GITHUB_REPOSITORIES entries: "
+            f"{', '.join(invalid)}. Expected comma-separated owner/repo names."
+        )
+    return repositories
+
+
 def _hf_namespace() -> str:
     value = os.environ.get("HF_NAMESPACE", "").strip()
     if value:
@@ -63,6 +82,7 @@ class Settings:
     runner_image_gpu: str
 
     # Behavior
+    allowed_github_repositories: frozenset[str] | None
     default_timeout: str  # "1h" etc.
     log_level: str
 
@@ -89,6 +109,7 @@ class Settings:
                 "RUNNER_IMAGE_GPU",
                 "nvidia/cuda:12.4.0-runtime-ubuntu22.04",
             ),
+            allowed_github_repositories=_allowed_github_repositories(),
             default_timeout=_optional("JOB_TIMEOUT", "1h"),
             log_level=_optional("LOG_LEVEL", "INFO"),
         )

--- a/dispatcher/tests/conftest.py
+++ b/dispatcher/tests/conftest.py
@@ -47,6 +47,7 @@ def settings(rsa_keypair) -> Settings:
         hf_namespace="testuser",
         runner_image_cpu="ghcr.io/test/jobs-actions-runner:cpu",
         runner_image_gpu="ghcr.io/test/jobs-actions-runner-gpu:gpu",
+        allowed_github_repositories=None,
         default_timeout="1h",
         log_level="DEBUG",
     )

--- a/dispatcher/tests/test_app.py
+++ b/dispatcher/tests/test_app.py
@@ -163,6 +163,54 @@ def test_queued_without_hf_label_skips(client, fake_hf):
     assert fake_hf.dispatches == []
 
 
+def test_queued_from_repository_outside_allowlist_skips(
+    client, fake_gh, fake_hf, settings
+):
+    object.__setattr__(
+        settings,
+        "allowed_github_repositories",
+        frozenset({"gradio-app/trackio", "huggingface/trl"}),
+    )
+    payload = workflow_job_payload(
+        action="queued",
+        labels=["hf-jobs-cpu-basic"],
+        repo="someone-else/expensive-ci",
+    )
+
+    r = _post(client, payload)
+
+    assert r.status_code == 200
+    assert r.json() == {
+        "ok": True,
+        "skipped": "repository not allowed",
+        "repo": "someone-else/expensive-ci",
+    }
+    assert fake_gh.calls == []
+    assert fake_hf.dispatches == []
+
+
+def test_queued_from_repository_inside_allowlist_dispatches(
+    client, fake_gh, fake_hf, settings
+):
+    object.__setattr__(
+        settings,
+        "allowed_github_repositories",
+        frozenset({"gradio-app/trackio", "huggingface/trl"}),
+    )
+    fake_gh.runner_tokens_by_repo["HuggingFace/TRL"] = "RUNNERTOKEN-XYZ"
+    payload = workflow_job_payload(
+        action="queued",
+        labels=["hf-jobs-cpu-basic"],
+        repo="HuggingFace/TRL",
+    )
+
+    r = _post(client, payload)
+
+    assert r.status_code == 200
+    assert r.json()["hf_job_id"].startswith("hfjob-")
+    assert len(fake_hf.dispatches) == 1
+
+
 def test_queued_with_self_hosted_and_hf_label_dispatches(client, fake_hf):
     payload = workflow_job_payload(
         action="queued",

--- a/dispatcher/tests/test_config.py
+++ b/dispatcher/tests/test_config.py
@@ -17,6 +17,7 @@ def base_env(monkeypatch, rsa_keypair):
     monkeypatch.delenv("HF_NAMESPACE", raising=False)
     monkeypatch.delenv("SPACE_AUTHOR_NAME", raising=False)
     monkeypatch.delenv("SPACE_ID", raising=False)
+    monkeypatch.delenv("ALLOWED_GITHUB_REPOSITORIES", raising=False)
 
 
 def test_hf_namespace_uses_explicit_override(base_env, monkeypatch):
@@ -40,4 +41,36 @@ def test_hf_namespace_falls_back_to_space_id_owner(base_env, monkeypatch):
 
 def test_hf_namespace_required_outside_space(base_env):
     with pytest.raises(RuntimeError, match="HF_NAMESPACE"):
+        Settings.from_env()
+
+
+def test_allowed_github_repositories_defaults_to_unrestricted(base_env, monkeypatch):
+    monkeypatch.setenv("SPACE_AUTHOR_NAME", "space-owner")
+
+    assert Settings.from_env().allowed_github_repositories is None
+
+
+def test_allowed_github_repositories_parses_and_normalizes(base_env, monkeypatch):
+    monkeypatch.setenv("SPACE_AUTHOR_NAME", "space-owner")
+    monkeypatch.setenv(
+        "ALLOWED_GITHUB_REPOSITORIES",
+        " Gradio-App/Trackio, huggingface/trl ",
+    )
+
+    assert Settings.from_env().allowed_github_repositories == frozenset(
+        {"gradio-app/trackio", "huggingface/trl"}
+    )
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["huggingface", "/trl", "huggingface/", "huggingface/trl/extra"],
+)
+def test_allowed_github_repositories_rejects_invalid_entries(
+    base_env, monkeypatch, value
+):
+    monkeypatch.setenv("SPACE_AUTHOR_NAME", "space-owner")
+    monkeypatch.setenv("ALLOWED_GITHUB_REPOSITORIES", value)
+
+    with pytest.raises(RuntimeError, match="ALLOWED_GITHUB_REPOSITORIES"):
         Settings.from_env()

--- a/setup/SETUP.md
+++ b/setup/SETUP.md
@@ -77,6 +77,7 @@ Add this as a regular **Variable**:
 | Name | Value |
 |---|---|
 | `GH_APP_ID` | The App ID from step 2 |
+| `ALLOWED_GITHUB_REPOSITORIES` | Recommended when the GitHub App is public. Comma-separated repositories allowed to launch Jobs, e.g. `gradio-app/trackio,huggingface/trl`. If unset, all repositories where the App is installed are allowed. |
 
 `HF_NAMESPACE` is optional. By default, jobs run under the owner namespace of the dispatcher Space. Set `HF_NAMESPACE` only if you want jobs billed to a different HF user or org.
 


### PR DESCRIPTION
## What changed

- add an optional `ALLOWED_GITHUB_REPOSITORIES` Space variable containing comma-separated `owner/repo` names
- reject queued jobs from repositories outside the allowlist before minting a GitHub token or launching an HF Job
- normalize repository names case-insensitively and fail startup on malformed entries
- document the variable for public GitHub App installations

## Why

A public GitHub App can be installed by accounts outside the intended repositories. Those installations produce valid signed webhooks, so the dispatcher needs its own authorization boundary to prevent unapproved repositories from launching Jobs billed through the configured `HF_TOKEN`.

The variable remains optional for backward compatibility with existing private or tightly scoped installations.

## Validation

- `pytest -q dispatcher/tests` — 46 passed
- `ruff check dispatcher/` — passed
