### PR TITLE
Fix dispatch and runner startup so jobs actually run

### DIFF
--- a/dispatcher/config.py
+++ b/dispatcher/config.py
@@ -104,10 +104,10 @@ class Settings:
             # care about cold-start latency can point these at prebuilt
             # ghcr.io/<their-org>/jobs-actions-runner[:tag] images instead;
             # see runner/Dockerfile{,.gpu}.
-            runner_image_cpu=_optional("RUNNER_IMAGE_CPU", "ubuntu:22.04"),
+            runner_image_cpu=_optional("RUNNER_IMAGE_CPU", "ubuntu:24.04"),
             runner_image_gpu=_optional(
                 "RUNNER_IMAGE_GPU",
-                "nvidia/cuda:12.4.0-runtime-ubuntu22.04",
+                "nvidia/cuda:12.9.2-runtime-ubuntu24.04",
             ),
             allowed_github_repositories=_allowed_github_repositories(),
             default_timeout=_optional("JOB_TIMEOUT", "1h"),

--- a/dispatcher/hf_jobs.py
+++ b/dispatcher/hf_jobs.py
@@ -6,6 +6,7 @@ We isolate HF Jobs interaction here so it can be mocked cleanly in tests.
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass
 
 from huggingface_hub import HfApi
@@ -14,6 +15,18 @@ from .flavors import LABEL_TO_FLAVOR, is_gpu_flavor
 from .runner_bootstrap import BOOTSTRAP
 
 log = logging.getLogger(__name__)
+
+_INVALID_LABEL_CHARS = re.compile(r"[^a-zA-Z0-9._-]")
+
+
+def sanitize_label_value(value: str) -> str:
+    """Coerce a label value to the charset HF Jobs accepts.
+
+    HF Jobs validates label values against `^[a-zA-Z0-9._-]*$` and rejects the
+    whole request otherwise. `gh-repo` is an `owner/name` slug, so the slash
+    would 400 every dispatch and leave the GitHub job queued forever.
+    """
+    return _INVALID_LABEL_CHARS.sub("_", value)
 
 
 @dataclass
@@ -79,8 +92,8 @@ class HFJobsClient:
             namespace=self._namespace,
             labels={
                 "managed-by": "jobs-actions",
-                "gh-repo": repo,
-                "gh-label": label,
+                "gh-repo": sanitize_label_value(repo),
+                "gh-label": sanitize_label_value(label),
             },
         )
         log.info(

--- a/dispatcher/runner_bootstrap.py
+++ b/dispatcher/runner_bootstrap.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 # Pin the GitHub Actions runner version. Bump in lockstep with whatever
 # GitHub is currently requiring; older versions get rejected during config.
-RUNNER_VERSION = "2.319.1"
+RUNNER_VERSION = "2.336.0"
 
 BOOTSTRAP = rf"""
 set -euo pipefail
@@ -34,7 +34,7 @@ echo "[jobs-actions] repo=${{GH_REPO}} labels=${{RUNNER_LABELS}} name=${{RUNNER_
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -qq
 apt-get install -qq -y --no-install-recommends \
-    ca-certificates curl git git-lfs jq libicu70 sudo \
+    ca-certificates curl git git-lfs jq sudo \
     >/dev/null
 
 useradd -m -s /bin/bash runner 2>/dev/null || true
@@ -63,12 +63,12 @@ sudo ./bin/installdependencies.sh >/dev/null
 
 cleanup() {{
     if [[ -f .runner ]]; then
-        sudo -u runner ./config.sh remove --token "${{RUNNER_TOKEN}}" 2>/dev/null || true
+        sudo -u runner -E env HOME=/home/runner ./config.sh remove --token "${{RUNNER_TOKEN}}" 2>/dev/null || true
     fi
 }}
 trap cleanup EXIT INT TERM
 
-sudo -u runner -E ./config.sh \
+sudo -u runner -E env HOME=/home/runner ./config.sh \
     --url "https://github.com/${{GH_REPO}}" \
     --token "${{RUNNER_TOKEN}}" \
     --name "${{RUNNER_NAME}}" \
@@ -77,5 +77,5 @@ sudo -u runner -E ./config.sh \
     --ephemeral --unattended --replace --disableupdate
 
 # Runner exits after one job thanks to --ephemeral.
-exec sudo -u runner -E ./run.sh
+exec sudo -u runner -E env HOME=/home/runner ./run.sh
 """

--- a/dispatcher/tests/test_hf_jobs.py
+++ b/dispatcher/tests/test_hf_jobs.py
@@ -96,8 +96,23 @@ def test_dispatch_includes_labels_for_grouping(patched_api):
     )
     labels = patched_api.run_job.call_args.kwargs["labels"]
     assert labels["managed-by"] == "jobs-actions"
-    assert labels["gh-repo"] == "myorg/myrepo"
+    assert labels["gh-repo"] == "myorg_myrepo"
     assert labels["gh-label"] == "hf-jobs-a10g-small"
+
+
+def test_dispatch_label_values_match_hf_jobs_charset(patched_api):
+    import re
+
+    c = _client()
+    c.dispatch(
+        label="hf-jobs-a10g-small",
+        repo="my org/my@repo#1",
+        runner_token="tok",
+        runner_name="hfjobs-1-2",
+    )
+    labels = patched_api.run_job.call_args.kwargs["labels"]
+    for value in labels.values():
+        assert re.fullmatch(r"[a-zA-Z0-9._-]*", value), value
 
 
 def test_cancel_calls_api(patched_api):


### PR DESCRIPTION
Four independent breakages, each of which leaves the GitHub `workflow_job` **queued forever** with its webhook already consumed (so it never self-heals — the run has to be cancelled and re-run). Hit in production on `gradio-app/trackio`.

### 1. HF Jobs rejects the `gh-repo` label

HF Jobs validates label **values** against `^[a-zA-Z0-9._-]*$`. `gh-repo` carries an `owner/name` slug, so the `/` now 400s every dispatch:

```
BadRequestError: Invalid string: must match pattern /^[a-zA-Z0-9._-]*$/
  → at labels["gh-repo"]
```

A 400 is non-transient, so `_retry_dispatch` re-raises rather than retrying. Fixed with `sanitize_label_value()` applied to all label values (`gradio-app/trackio` → `gradio-app_trackio`).

### 2. Runner v2.319.1 is deprecated

```
Current runner version: '2.319.1'
An error occured: Error: Forbidden Runner version v2.319.1 is deprecated and cannot receive messages.
```

The runner registers, connects, then exits without claiming the job. We pass `--disableupdate`, so it cannot self-upgrade out of this. Bumped to 2.336.0.

### 3. 2.336.0's dependencies don't exist on Ubuntu 22.04

`installdependencies.sh` targets the t64 ABI packages and probes `libicu80` down to `libicu71`:

```
E: Unable to locate package liblttng-ust1t64
E: Unable to locate package libssl3t64
E: Unable to locate package libicu80 … libicu71
```

22.04 ships `libicu70`/`libssl3`/`liblttng-ust1`, so none resolve. Default images moved to 24.04 (which has `libicu74`), and the hardcoded `libicu70` dropped from our apt list — `installdependencies.sh` picks the right ICU itself.

### 4. The runner inherits `HOME=/root`

The bootstrap runs the runner as the unprivileged `runner` user via `sudo -E`, which preserves `HOME=/root` from the container. `actions/checkout` then stats root's gitconfig as `runner`:

```
##[error]EACCES: permission denied, stat '/root/.gitconfig'
```

Fixed by passing `HOME=/home/runner` (already created by `useradd -m`).

## Verification

Each layer was verified on HF Jobs rather than by inspection: dispatch returns 200 and logs `queued -> dispatched`; the runner installs deps, unpacks, and reports `2.336.0`; and a full GitHub Actions job now runs to `completed/success` on a self-hosted `hf-jobs-cpu-upgrade` runner.

Note for operators pinning `RUNNER_IMAGE_CPU`: if your image provided workload tools, re-check them on 24.04. The Playwright `-jammy` image ships `/usr/bin/ffmpeg`; `-noble` does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)