### PR TITLE
Periods are not valid label characters

### DIFF
--- a/dispatcher/hf_jobs.py
+++ b/dispatcher/hf_jobs.py
@@ -16,13 +16,13 @@ from .runner_bootstrap import BOOTSTRAP
 
 log = logging.getLogger(__name__)
 
-_INVALID_LABEL_CHARS = re.compile(r"[^a-zA-Z0-9._-]")
+_INVALID_LABEL_CHARS = re.compile(r"[^a-zA-Z0-9_-]")
 
 
 def sanitize_label_value(value: str) -> str:
     """Coerce a label value to the charset HF Jobs accepts.
 
-    HF Jobs validates label values against `^[a-zA-Z0-9._-]*$` and rejects the
+    HF Jobs validates label values against `^[a-zA-Z0-9_-]*$` and rejects the
     whole request otherwise. `gh-repo` is an `owner/name` slug, so the slash
     would 400 every dispatch and leave the GitHub job queued forever.
     """


### PR DESCRIPTION
Update `_INVALID_LABEL_CHARS` so that a job does not fail due to `JobSpec.tags` containing a period when f.ex. the repository has a period in its name (`llama.cpp`).

See [_jobs_api.py:_sanitize_job_name](https://github.com/huggingface/huggingface_hub/blob/5377009cbc410f86864bfa4faa86f7a98645f295/src/huggingface_hub/_jobs_api.py#L522-L528)