### PR TITLE
Prevent HF runners from picking unrelated jobs

### DIFF
--- a/dispatcher/runner_bootstrap.py
+++ b/dispatcher/runner_bootstrap.py
@@ -73,6 +73,7 @@ sudo -u runner -E env HOME=/home/runner ./config.sh \
     --token "${{RUNNER_TOKEN}}" \
     --name "${{RUNNER_NAME}}" \
     --labels "${{RUNNER_LABELS}}" \
+    --no-default-labels \
     --work _work \
     --ephemeral --unattended --replace --disableupdate
 

--- a/runner/entrypoint.sh
+++ b/runner/entrypoint.sh
@@ -42,6 +42,7 @@ trap cleanup EXIT INT TERM
     --token "${RUNNER_TOKEN}" \
     --name "${RUNNER_NAME}" \
     --labels "${RUNNER_LABELS}" \
+    --no-default-labels \
     --runnergroup "${RUNNER_GROUP}" \
     --work "${RUNNER_WORKDIR}" \
     --ephemeral \


### PR DESCRIPTION
## Summary

Register jobs-actions runners without GitHub's automatic `self-hosted`, OS, and architecture labels.

Without `--no-default-labels`, an ephemeral HF Jobs runner created for an `hf-jobs-*` job can also match an unrelated job using generic labels such as `[self-hosted, Linux, X64]`. If GitHub assigns that job first, the runner exits after it and leaves the intended job queued.

Apply the flag to both the prebuilt entrypoint and inline bootstrap registration paths.

## Verification

- `bash -n runner/entrypoint.sh`
- `python3 -m pytest -q -p no:rerunfailures` (47 passed)
- `ruff check .`